### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
                 "codeigniter/framework": "~3.1"
 	},
 	"require-dev": {
-		"mikey179/vfsStream": "1.1.*",
+		"mikey179/vfsstream": "1.1.*",
 		"phpunit/phpunit": "4.* || 5.*"
 	},
 	"suggest": {


### PR DESCRIPTION
line 12 "mikey179/vfsStream": "1.1.*" is making this error
Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.

changing it to lower case fix the problem